### PR TITLE
[FIX] Advanced map mode: Fix non-generators hiding their details

### DIFF
--- a/jui/UINode.hx
+++ b/jui/UINode.hx
@@ -71,6 +71,7 @@ class UINode
 
       // different borders
       var dd = 0;
+      tempd = 0;
       temph = 17;
 	  if (node.isGenerator)
 		{


### PR DESCRIPTION
Initialized to `null`, adding this to any number will yield `NaN`.
Painting to `NaN` however does exactly what one would assume: nothing.