### PR TITLE
Advanced mode: Indicate what kinds of resources a generator produces

### DIFF
--- a/jui/UINode.hx
+++ b/jui/UINode.hx
@@ -156,6 +156,24 @@ class UINode
           node.y > ui.map.viewRect.y + ui.map.viewRect.h)
         return;
 
+      // Draw production indicators
+      var productionIndicatorWidth = 6;
+      var productionIndicatorHeight = 2;
+      if (node.isGenerator && !node.isTempGenerator)
+        if (node.owner == null || node.isKnown[game.player.id])
+          {
+            for (i in 0...Game.numPowers)
+              if (node.powerGenerated[i] > 0)
+                {
+                  ctx.fillStyle = UI.powerColors[i];
+                  ctx.fillRect(
+                    tempx + (tempd - 1) + i*(productionIndicatorWidth+1),
+                    tempy - productionIndicatorHeight,
+                    productionIndicatorWidth,
+                    productionIndicatorHeight);
+                }
+          }
+
       // chance to gain node
       if (node.owner != game.player)
         {


### PR DESCRIPTION
![selection_117](https://user-images.githubusercontent.com/373440/30826908-7975e27e-a238-11e7-91f1-7b06a3fdfedd.png)  
If you could obtain the same information from the tooltips in standard
mode. Shows as colored stripes on top of generator nodes (between the
border and success percentage, if such is present).

Other placements I tried and was not satisified with:
 - Left/Right side of the node (looked pretty weird for origin nodes)
 - Inside the top border (same, plus terrible contrast with linked ones)
 - Below the node, shifting down power line (node-block felt too big)

"Given two generators, which one should I go for first?" and, closely
related, "Does this expensive generator produce 2+ resources?" were
two questions that could not be answered in advanced mode before.
Now, at least you partially receive visual help here: Seeing two stripes
definitely indicates two or more resources being produced, and seeing
differently-colored stripes for otherwise identical/similar nodes can
affect your decisions based on resource production needs.

The corner case of a generator producing multiple units of the same
resource still technically requires you to check out the node tooltip.
This however doesn't happen as often and usually you only have to get
"suspicious" if the node seems to come with a price tag too hefty for
just one resource item being produced.